### PR TITLE
Missing psc in municipalities_sk.json

### DIFF
--- a/municipalities_sk.json
+++ b/municipalities_sk.json
@@ -1272,6 +1272,11 @@
       "96661"
     ]
   },
+  "Hodruša - Hámre": {
+    "postalCodes": [
+      "96663"
+    ]
+  },
   "Holice": {
     "postalCodes": [
       "93034"
@@ -4153,6 +4158,11 @@
   "Rokytov": {
     "postalCodes": [
       "08601"
+    ]
+  },
+  "Rokytov pri Humennom": {
+    "postalCodes": [
+      "06713"
     ]
   },
   "Rosina": {


### PR DESCRIPTION
file `municipalities_sk.json` is missing these 2 postal codes that are provided in`postalcodecoordinates_sk.json`

I've also created PR for  `joined_postalcodes_sk.json`   https://github.com/OpenDataSk/datasets/pull/4 